### PR TITLE
Add a Code field to Forecast

### DIFF
--- a/v2/forecast.go
+++ b/v2/forecast.go
@@ -75,6 +75,7 @@ type Forecast struct {
 	Alerts    []alert   `json:"alerts"`
 	Flags     Flags     `json:"flags"`
 	APICalls  int       `json:"apicalls"`
+	Code      int       `json:"code"`
 }
 
 type Units string


### PR DESCRIPTION
This is in the service of justincampbell/emoji-weather#9. I have a local change that I'll be pushing up momentarily which will show :exclamation: when forecast.io returns an HTTP error code in their response body.
